### PR TITLE
Optional `options` parameter for play function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface PlayOptions {
   playbackRate?: number;
 }
 
-export type PlayFunction = (options: PlayOptions) => void;
+export type PlayFunction = (options?: PlayOptions) => void;
 
 export interface ExposedData {
   sound: Howl | null;


### PR DESCRIPTION
The `options` parameter should be optional. It is in the code, so let's update the types ;)