### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ To play a specific sprite, we'll pass its `id` when calling the `play` function:
 
 ```js
 <button
-  onClick={() => play('laser')}
+  onClick={() => play({id: 'laser'})}
 >
 ```
 


### PR DESCRIPTION
This changes a typo in the Sprites section of the readme where it was incorrectly telling users to pass the id as an argument to `play`, when it should actually be passed as the `id` property of the `PlayOptions` object.