### PR TITLE
Added Typescript types for unrecognised options in HookOptions

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,26 +1,44 @@
 /// <reference types="howler" />
 export declare type SpriteMap = {
-    [key: string]: [number, number];
+  [key: string]: [number, number];
 };
-export interface HookOptions {
-    volume?: number;
-    playbackRate?: number;
-    interrupt?: boolean;
-    soundEnabled?: boolean;
-    sprite?: SpriteMap;
-    onload?: () => void;
+
+export interface IHowlProperties {
+  autoplay?: boolean;
+  buffer?: boolean;
+  duration?: number;
+  format?: string;
+  loop?: boolean;
+  src?: string;
+  volume?: number;
+  urls?: string[];
+  rate?: number;
+  model?: 'equalpower' | 'HRTF';
+  onend?: Function;
+  onloaderror?: Function;
+  onpause?: Function;
+  onplay?: Function;
+}
+
+export interface HookOptions extends IHowlProperties {
+  volume?: number;
+  playbackRate?: number;
+  interrupt?: boolean;
+  soundEnabled?: boolean;
+  sprite?: SpriteMap;
+  onload?: () => void;
 }
 export interface PlayOptions {
-    id?: string;
-    forceSoundEnabled?: boolean;
-    playbackRate?: number;
+  id?: string;
+  forceSoundEnabled?: boolean;
+  playbackRate?: number;
 }
 export declare type PlayFunction = (options: PlayOptions) => void;
 export interface ExposedData {
-    sound: Howl | null;
-    stop: (id?: string) => void;
-    pause: (id?: string) => void;
-    isPlaying: boolean;
-    duration: number | null;
+  sound: Howl | null;
+  stop: (id?: string) => void;
+  pause: (id?: string) => void;
+  isPlaying: boolean;
+  duration: number | null;
 }
 export declare type ReturnedValue = [PlayFunction, ExposedData];

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,24 @@ export type SpriteMap = {
   [key: string]: [number, number];
 };
 
-export interface HookOptions {
+export interface IHowlProperties {
+  autoplay?: boolean;
+  buffer?: boolean;
+  duration?: number;
+  format?: string;
+  loop?: boolean;
+  src?: string;
+  volume?: number;
+  urls?: string[];
+  rate?: number;
+  model?: 'equalpower' | 'HRTF';
+  onend?: Function;
+  onloaderror?: Function;
+  onpause?: Function;
+  onplay?: Function;
+}
+
+export interface HookOptions extends IHowlProperties {
   volume?: number;
   playbackRate?: number;
   interrupt?: boolean;


### PR DESCRIPTION
When using with typescript, passing unknown options in HookOptions causes errors. This PR fixes the issue by extending IHowlProperties as mentioned in #18.