### PR TITLE
Correct usage of play function with sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ To play a specific sprite, we'll pass its `id` when calling the `play` function:
 
 ```js
 <button
-  onClick={() => play('laser')}
+  onClick={() => play({id: 'laser')}
 >
 ```
 


### PR DESCRIPTION
I could not use the play function for sprites as suggested in the README. `play({id: 'laser')}` worked for me tho, so this reflects the correct usage in the README.