### PR TITLE
Add support for looping sounds to isPaying state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,12 @@ export default function useSound(
 
       sound.play(options.id);
 
-      sound.once('end', () => setIsPlaying(false));
+      sound.once('end', () => {
+        // If sound is not looping
+        if (!sound.playing()) {
+          setIsPlaying(false);
+        }
+      });
 
       setIsPlaying(true);
     },


### PR DESCRIPTION
Hi Josh, I found that Howler emits an `end` event on looping sounds each time it plays. This code change enables the isPlaying state to support looping sounds. It fixes the issue I described here: https://github.com/joshwcomeau/use-sound/issues/26#issuecomment-719792452