### PR TITLE
Allow hook options to be extended with HowlOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import useOnMount from './use-on-mount';
 
 import { HookOptions, PlayOptions, PlayFunction, ReturnedValue } from './types';
 
-export default function useSound(
+export default function useSound<T = any>(
   url: string,
   {
     volume = 1,
@@ -13,7 +13,7 @@ export default function useSound(
     interrupt = false,
     onload,
     ...delegated
-  }: HookOptions = {}
+  }: HookOptions<T> = {} as HookOptions
 ) {
   const HowlConstructor = React.useRef<HowlStatic | null>(null);
   const isMounted = React.useRef(false);
@@ -170,3 +170,5 @@ export default function useSound(
 
   return returnedValue;
 }
+
+export { useSound };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,14 @@ export type SpriteMap = {
   [key: string]: [number, number];
 };
 
-export interface HookOptions {
+export type HookOptions<T = any> = T & {
   volume?: number;
   playbackRate?: number;
   interrupt?: boolean;
   soundEnabled?: boolean;
   sprite?: SpriteMap;
   onload?: () => void;
-}
+};
 
 export interface PlayOptions {
   id?: string;


### PR DESCRIPTION
**Issue**: https://github.com/joshwcomeau/use-sound/issues/18

**Versions**:
Tested in my project on the following lib versions
- Typescript: 4.0.5
- React: 17.0.1
- use-sound: latest

**Description**: This fix does not change the default hook behavior, however, it allows to specify set of options from `HowlOptions` and enables IDE support for them

Usage:
```js
import useSound from 'use-sound';
import {HowlOptions} from "howler";

import soundfile from './assets/sounds/test.ogg';

const Player = ({url, volume}: PlayerProps) => {
  const [play, {isPlaying, pause}] = useSound<HowlOptions>(url, {
    volume: volume,
    loop: true,
    onend: () => {console.log('===== ENDED');}
  });

  return <div className='player'>
    {isPlaying ?
        <PauseImg onClick={() => pause()}/> :
        <PlayImg onClick={() => play()} />
    }
  </div>
};

...

<Player url={soundfile} volume={0.2}/>
```

It's still usable w/o any extensions
```js
const [play] = useSound(soundfile);
```

**NOTE**: exporting hook not only as module default will allow to augment and add overrides to the hook if needed