### PR TITLE
Add support for multiple sources (proxy to Howl)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import { HookOptions, ReturnedValue } from './types';
 export default function useSound(
-  url: string,
+  src: string | string[],
   {
     volume,
     playbackRate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import useOnMount from './use-on-mount';
 import { HookOptions, PlayOptions, PlayFunction, ReturnedValue } from './types';
 
 export default function useSound(
-  url: string,
+  src: string | string[],
   {
     volume = 1,
     playbackRate = 1,
@@ -43,7 +43,7 @@ export default function useSound(
         isMounted.current = true;
 
         const sound = new HowlConstructor.current({
-          src: [url],
+          src: Array.isArray(src) ? src : [src],
           volume,
           rate: playbackRate,
           onload: handleLoad,
@@ -59,14 +59,14 @@ export default function useSound(
     };
   });
 
-  // When the URL changes, we have to do a whole thing where we recreate
+  // When the `src` changes, we have to do a whole thing where we recreate
   // the Howl instance. This is because Howler doesn't expose a way to
   // tweak the sound
   React.useEffect(() => {
     if (HowlConstructor.current && sound) {
       setSound(
         new HowlConstructor.current({
-          src: [url],
+          src: Array.isArray(src) ? src : [src],
           volume,
           onload: handleLoad,
           ...delegated,
@@ -75,9 +75,12 @@ export default function useSound(
     }
     // The linter wants to run this effect whenever ANYTHING changes,
     // but very specifically I only want to recreate the Howl instance
-    // when the `url` changes. Other changes should have no effect.
+    // when the `src` changes. Other changes should have no effect.
+    // Passing array to the useEffect dependencies list will result in
+    // ifinite loop so we need to stringify it, for more details check
+    // https://github.com/facebook/react/issues/14476#issuecomment-471199055
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [url]);
+  }, [JSON.stringify(src)]);
 
   // Whenever volume/playbackRate are changed, change those properties
   // on the sound instance.

--- a/stories/demos/SimpleMultipleSources.js
+++ b/stories/demos/SimpleMultipleSources.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import useSound from '@';
+
+import sound1 from '../sounds/pop-off.wav';
+import sound2 from '../sounds/pop-off.mp3';
+
+import Button from '../helpers/Button';
+
+
+const sourceOrderMapping = {
+  'wav_mp3': [sound1, sound2],
+  'mp3_wav': [sound2, sound1],
+};
+
+const MultipleSourcesDemo = ({order}) => {
+  const [play] = useSound(sourceOrderMapping[order]);
+
+  return <Button onClick={play}>Play sound</Button>;
+};
+
+export default MultipleSourcesDemo;

--- a/stories/use-sound.stories.d.ts
+++ b/stories/use-sound.stories.d.ts
@@ -35,3 +35,9 @@ export declare const DrumMachine: {
         name: string;
     };
 };
+export declare const MultipleSources: {
+    (): JSX.Element;
+    story: {
+        name: string;
+    };
+};

--- a/stories/use-sound.stories.tsx
+++ b/stories/use-sound.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, radios } from '@storybook/addon-knobs';
 
 import Wrapper from './helpers/Wrapper';
 
@@ -8,6 +8,7 @@ import SimpleDemo from './demos/Simple';
 import HoverDemo from './demos/Hover';
 import RisingDemo from './demos/Rising';
 import DrumMachineDemo from './demos/DrumMachine';
+import MultipleSourcesDemo from './demos/SimpleMultipleSources';
 
 import 'focus-visible';
 
@@ -58,4 +59,17 @@ export const DrumMachine = () => {
 
 DrumMachine.story = {
   name: 'Drum machine (sprites)',
+};
+
+export const MultipleSources = () => {
+  const options = {
+    'wav/mp3': 'wav_mp3',
+    'mp3/wav': 'mp3_wav'
+  };
+  const value = radios('Source', options, 'wav_mp3', 'group1');
+  return <MultipleSourcesDemo order={value}/>;
+};
+
+MultipleSources.story = {
+  name: 'Multiple sources support',
 };


### PR DESCRIPTION
**Issue**: https://github.com/joshwcomeau/use-sound/issues/17

**Description**: This PR allows passing multiple source files to the Howl constructor (see [howler.src](https://github.com/goldfire/howler.js#src-arraystring--required))

Usage:
```js
import soundfile1 from './assets/sounds/test.ogg';
import soundfile2 from './assets/sounds/test.mp3';

const Player = () => {
  const [play] = useSound([soundfile1, soundfile2]);

  return <div onClick={() => play()}>Play</div>;
};

...

<Player />
```

Old behavior stays and prev codebase should not be affected
```js
const [play] = useSound(soundfile1);
```
