### PR TITLE
fix: add conditional exports for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "use-sound",
   "author": "Josh Comeau",
   "module": "dist/use-sound.esm.js",
+  "exports": {
+    "import": "./dist/use-sound.esm.mjs",
+    "require": "./dist/index.js"
+  },
   "version": "2.0.1",
   "repository": "github:joshwcomeau/use-sound",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "use-sound",
   "author": "Josh Comeau",
   "module": "dist/use-sound.esm.js",
+  "type": "module",
   "exports": {
     "import": "./dist/use-sound.esm.mjs",
     "require": "./dist/index.js"


### PR DESCRIPTION
for ESM tools like snowpack, esinstall, etc., we need an `exports` property to define [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports). this will make `use-sound` compatible with ESM-focused frameworks like Toast