### PR TITLE
Fix path in conditional import for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "module": "dist/use-sound.esm.js",
   "type": "module",
   "exports": {
-    "import": "./dist/use-sound.esm.mjs",
+    "import": "./dist/use-sound.esm.js",
     "require": "./dist/index.js"
   },
   "version": "2.0.2",


### PR DESCRIPTION
There is no path like `./dist/use-sound.esm.mjs`, only `./dist/use-sound.esm.js`.
It fixes build error `Module not found: Error: Can't resolve 'use-sound'` in bundlers such as Webpack.