### PR TITLE
Update types.d.ts

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,7 @@
 /// <reference types="howler" />
+
+import { Howl } from "howler";
+
 export declare type SpriteMap = {
   [key: string]: [number, number];
 };


### PR DESCRIPTION
adding `import { Howl } from "howler";` to `types.d.ts`

Apparently in when i tried to build this using Typescript, i got "Cannot find name 'Howl'.ts(2304)". So when i tried to preview it on netlify, i got this : 

![image](https://user-images.githubusercontent.com/1050880/146120213-d69d456b-7146-4697-b980-7034d9ea3b2d.png)

It's a trivial change but i do think it's going to hold people back from using your package in Typescript.