### PR TITLE
export type from the exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "4.0.1",
   "module": "dist/use-sound.esm.js",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/use-sound.esm.js",
     "require": "./dist/index.js"
   },


### PR DESCRIPTION
So just importing with use sound gives an error that you can't resolve the types 
<img width="789" alt="Screenshot 2023-10-01 at 12 31 57" src="https://github.com/joshwcomeau/use-sound/assets/22987951/480e7634-bcea-46ec-9d92-271f0462048f">
to fix this `are the types wrong says` that they are wrong https://arethetypeswrong.github.io/?p=use-sound%404.0.1

Great article on publishing npm package that dropped recently https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/
