### PR TITLE
Add `loop` to `HookOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ When calling `useSound`, you can pass it a variety of options:
 | playbackRate | number    |
 | interrupt    | boolean   |
 | soundEnabled | boolean   |
+| loop         | boolean   |
 | sprite       | SpriteMap |
 | [delegated]  | —         |
 
@@ -220,6 +221,7 @@ When calling `useSound`, you can pass it a variety of options:
 - `playbackRate` is a number from `0.5` to `4`. It can be used to slow down or speed up the sample. Like a turntable, changes to speed also affect pitch.
 - `interrupt` specifies whether or not the sound should be able to "overlap" if the `play` function is called again before the sound has ended.
 - `soundEnabled` allows you to pass a value (typically from context or redux or something) to mute all sounds. Note that this can be overridden in the `PlayOptions`, see below
+- `loop` wether or not the sound should loop until the `stop` function is called
 - `sprite` allows you to use a single `useSound` hook for multiple sound effects. See [“Sprites”](https://github.com/joshwcomeau/use-sound#sprites) below.
 
 `[delegated]` refers to the fact that any additional argument you pass in `HookOptions` will be forwarded to the `Howl` constructor. See "Escape hatches" below for more information.

--- a/package.json
+++ b/package.json
@@ -73,5 +73,9 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5"
+  },
+  "volta": {
+    "node": "13.12.0",
+    "yarn": "1.22.22"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ export default function useSound(
     playbackRate,
     soundEnabled,
     interrupt,
+    loop,
     onload,
     ...delegated
   }?: HookOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export default function useSound<T = any>(
     playbackRate = 1,
     soundEnabled = true,
     interrupt = false,
+    loop = false,
     onload,
     ...delegated
   }: HookOptions<T> = {} as HookOptions
@@ -53,6 +54,7 @@ export default function useSound<T = any>(
           volume,
           rate: playbackRate,
           onload: handleLoad,
+          loop,
           ...delegated,
         });
       }
@@ -73,6 +75,7 @@ export default function useSound<T = any>(
           src: Array.isArray(src) ? src : [src],
           volume,
           onload: handleLoad,
+          loop,
           ...delegated,
         })
       );
@@ -86,19 +89,20 @@ export default function useSound<T = any>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(src)]);
 
-  // Whenever volume/playbackRate are changed, change those properties
+  // Whenever volume/playbackRate/loop are changed, change those properties
   // on the sound instance.
   React.useEffect(() => {
     if (sound) {
       sound.volume(volume);
       sound.rate(playbackRate);
+      sound.loop(loop);
     }
     // A weird bug means that including the `sound` here can trigger an
     // error on unmount, where the state loses track of the sprites??
     // No idea, but anyway I don't need to re-run this if only the `sound`
     // changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [volume, playbackRate]);
+  }, [volume, playbackRate, loop]);
 
   const play: PlayFunction = React.useCallback(
     (options?: PlayOptions) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,7 @@ export interface HookOptions {
   soundEnabled?: boolean;
   sprite?: SpriteMap;
   onload?: () => void;
+  loop?: boolean;
 }
 export interface PlayOptions {
   id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type HookOptions<T = any> = T & {
   soundEnabled?: boolean;
   sprite?: SpriteMap;
   onload?: () => void;
+  loop?: boolean;
 };
 
 export interface PlayOptions {


### PR DESCRIPTION
After using this library myself and needing to loop a sound, I discovered that Howler exposes an option for looping sounds. We can already use this through `delegated`  in `HookOptions`. 

After looking through some of the issues, there seems to be some confusion around how to loop sounds. This PR solves that 
confusion by making the following changes.

## Changes
- Adding a `boolean` property `loop` to `HookOptions` 
- Adding documentation for said `loop` property
- Updating the `loop` property on `sound` in `useEffect`

## Closes issues
- https://github.com/joshwcomeau/use-sound/issues/137