### PR TITLE
Fix lazy-load race conditions and cleanup behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,49 +17,41 @@ export default function useSound<T = any>(
   }: HookOptions<T> = {} as HookOptions
 ) {
   const HowlConstructor = React.useRef<HowlStatic | null>(null);
+  const isHowlerLoaded = React.useRef(false);
+  const latestLoadId = React.useRef(0);
+  const activeSoundRef = React.useRef<Howl | null>(null);
   const isMounted = React.useRef(false);
 
   const [duration, setDuration] = React.useState<number | null>(null);
+  const [isReady, setIsReady] = React.useState(false);
 
   const [sound, setSound] = React.useState<Howl | null>(null);
 
-  const handleLoad = function() {
-    if (typeof onload === 'function') {
-      // @ts-ignore
-      onload.call(this);
-    }
-
-    if (isMounted.current) {
-      // @ts-ignore
-      setDuration(this.duration() * 1000);
-    }
-
-    // @ts-ignore
-    setSound(this);
-  };
-
   // We want to lazy-load Howler, since sounds can't play on load anyway.
   useOnMount(() => {
+    isMounted.current = true;
+
     import('howler').then(mod => {
       if (!isMounted.current) {
-        // Depending on the module system used, `mod` might hold
-        // the export directly, or it might be under `default`.
-        HowlConstructor.current = mod.Howl ?? mod.default.Howl;
-
-        isMounted.current = true;
-
-        new HowlConstructor.current({
-          src: Array.isArray(src) ? src : [src],
-          volume,
-          rate: playbackRate,
-          onload: handleLoad,
-          ...delegated,
-        });
+        return;
       }
+
+      // Depending on the module system used, `mod` might hold
+      // the export directly, or it might be under `default`.
+      HowlConstructor.current = mod.Howl ?? mod.default.Howl;
+      isHowlerLoaded.current = true;
+      setIsReady(true);
     });
 
     return () => {
       isMounted.current = false;
+      isHowlerLoaded.current = false;
+      latestLoadId.current += 1;
+      if (activeSoundRef.current) {
+        activeSoundRef.current.stop();
+        activeSoundRef.current.unload();
+        activeSoundRef.current = null;
+      }
     };
   });
 
@@ -67,16 +59,42 @@ export default function useSound<T = any>(
   // the Howl instance. This is because Howler doesn't expose a way to
   // tweak the sound
   React.useEffect(() => {
-    if (HowlConstructor.current && sound) {
-      setSound(
-        new HowlConstructor.current({
-          src: Array.isArray(src) ? src : [src],
-          volume,
-          onload: handleLoad,
-          ...delegated,
-        })
-      );
+    if (!HowlConstructor.current || !isHowlerLoaded.current) {
+      return;
     }
+
+    const currentLoadId = latestLoadId.current + 1;
+    latestLoadId.current = currentLoadId;
+
+    const handleLoad = function(this: Howl) {
+      if (typeof onload === 'function') {
+        onload.call(this);
+      }
+
+      if (!isMounted.current || currentLoadId !== latestLoadId.current) {
+        return;
+      }
+
+      setDuration(this.duration() * 1000);
+    };
+
+    const nextSound = new HowlConstructor.current({
+      src: Array.isArray(src) ? src : [src],
+      volume,
+      rate: playbackRate,
+      onload: handleLoad,
+      ...delegated,
+    });
+
+    setSound(previousSound => {
+      if (previousSound) {
+        previousSound.stop();
+        previousSound.unload();
+      }
+      return nextSound;
+    });
+    activeSoundRef.current = nextSound;
+
     // The linter wants to run this effect whenever ANYTHING changes,
     // but very specifically I only want to recreate the Howl instance
     // when the `src` changes. Other changes should have no effect.
@@ -84,7 +102,7 @@ export default function useSound<T = any>(
     // ifinite loop so we need to stringify it, for more details check
     // https://github.com/facebook/react/issues/14476#issuecomment-471199055
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(src)]);
+  }, [JSON.stringify(src), isReady]);
 
   // Whenever volume/playbackRate are changed, change those properties
   // on the sound instance.
@@ -97,7 +115,7 @@ export default function useSound<T = any>(
         sound.rate(playbackRate);
       }
     }
-  }, [sound, volume, playbackRate]);
+  }, [sound, volume, playbackRate, delegated.sprite]);
 
   const play: PlayFunction = React.useCallback(
     (options?: PlayOptions) => {


### PR DESCRIPTION
## Summary
- rework initialization so `useSound` instantiates a `Howl` when Howler finishes lazy-loading, preventing stale `src` races
- replace old `Howl` instances on `src` changes and unload/stop instances on unmount to prevent lingering playback
- ensure async `onload` callbacks only update state for the latest active sound instance

## Test plan
- [x] `npm run lint`
- [x] `npm test -- --passWithNoTests`
- [ ] Manually verify changing `src` immediately after mount still plays the latest sound
- [ ] Manually verify unmount stops active playback

Made with [Cursor](https://cursor.com)